### PR TITLE
Add login flow

### DIFF
--- a/my-blog/src/App.tsx
+++ b/my-blog/src/App.tsx
@@ -2,19 +2,44 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Home from './pages/Home';
 import PostPage from './pages/PostPage';
 import ThemeToggle from './components/ThemeToggle';
-import EditPost from './pages/PostPage';
+import EditPost from './pages/EditPost';
+import LoginPage from './pages/Login';
+import RequireAuth from './components/RequireAuth';
 
 function App() {
   return (
     <BrowserRouter>
       <ThemeToggle />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/post/:id" element={<PostPage />} />
-        <Route path="/edit/:id" element={<EditPost />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route
+          path="/"
+          element={(
+            <RequireAuth>
+              <Home />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/post/:id"
+          element={(
+            <RequireAuth>
+              <PostPage />
+            </RequireAuth>
+          )}
+        />
+        <Route
+          path="/edit/:id"
+          element={(
+            <RequireAuth>
+              <EditPost />
+            </RequireAuth>
+          )}
+        />
       </Routes>
     </BrowserRouter>
   );
 }
 
 export default App;
+

--- a/my-blog/src/components/RequireAuth.tsx
+++ b/my-blog/src/components/RequireAuth.tsx
@@ -1,0 +1,15 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+function RequireAuth({ children }: { children: JSX.Element }) {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  return children;
+}
+
+export default RequireAuth;
+

--- a/my-blog/src/components/ThemeToggle.tsx
+++ b/my-blog/src/components/ThemeToggle.tsx
@@ -1,12 +1,22 @@
 import { useTheme } from '../context/ThemeContext';
+import { useAuth } from '../context/AuthContext';
 
 function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const { isAuthenticated, logout } = useAuth();
   return (
-    <button className="theme-toggle" onClick={toggleTheme}>
-      {theme === 'dark' ? '☀️ حالت روشن' : '🌙 حالت تیره'}
-    </button>
+    <div className="theme-toggle">
+      <button onClick={toggleTheme}>
+        {theme === 'dark' ? '☀️ حالت روشن' : '🌙 حالت تیره'}
+      </button>
+      {isAuthenticated && (
+        <button style={{ marginLeft: '0.5rem' }} onClick={logout}>
+          خروج
+        </button>
+      )}
+    </div>
   );
 }
 
 export default ThemeToggle;
+

--- a/my-blog/src/context/AuthContext.tsx
+++ b/my-blog/src/context/AuthContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+interface AuthContextProps {
+  isAuthenticated: boolean;
+  login: (username: string, password: string) => boolean;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextProps | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('auth');
+    if (stored === 'true') {
+      setIsAuthenticated(true);
+    }
+  }, []);
+
+  const login = (username: string, password: string) => {
+    if (username === 'admin' && password === 'password') {
+      setIsAuthenticated(true);
+      localStorage.setItem('auth', 'true');
+      return true;
+    }
+    return false;
+  };
+
+  const logout = () => {
+    setIsAuthenticated(false);
+    localStorage.removeItem('auth');
+  };
+
+  return (
+    <AuthContext.Provider value={{ isAuthenticated, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+};
+

--- a/my-blog/src/main.tsx
+++ b/my-blog/src/main.tsx
@@ -4,13 +4,16 @@ import App from './App';
 import './index.css';
 import { BlogProvider } from './context/BlogContext';
 import { ThemeProvider } from './context/ThemeContext';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider>
-      <BlogProvider>
-        <App />
-      </BlogProvider>
+      <AuthProvider>
+        <BlogProvider>
+          <App />
+        </BlogProvider>
+      </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>
 );

--- a/my-blog/src/pages/Login.tsx
+++ b/my-blog/src/pages/Login.tsx
@@ -1,0 +1,50 @@
+import { useForm } from 'react-hook-form';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+interface LoginInput {
+  username: string;
+  password: string;
+}
+
+function LoginPage() {
+  const { register, handleSubmit, formState: { errors } } = useForm<LoginInput>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { login } = useAuth();
+
+  const from = (location.state as { from?: Location })?.from?.pathname || '/';
+
+  const onSubmit = (data: LoginInput) => {
+    if (login(data.username, data.password)) {
+      navigate(from, { replace: true });
+    } else {
+      alert('نام کاربری یا گذرواژه اشتباه است');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="container">
+      <h1>ورود</h1>
+      <input
+        {...register('username', { required: 'نام کاربری الزامی است' })}
+        placeholder="نام کاربری"
+      />
+      {errors.username && (
+        <p style={{ color: 'red' }}>{errors.username.message}</p>
+      )}
+      <input
+        type="password"
+        {...register('password', { required: 'گذرواژه الزامی است' })}
+        placeholder="گذرواژه"
+      />
+      {errors.password && (
+        <p style={{ color: 'red' }}>{errors.password.message}</p>
+      )}
+      <button type="submit">ورود</button>
+    </form>
+  );
+}
+
+export default LoginPage;
+


### PR DESCRIPTION
## Summary
- introduce `AuthContext` with login/logout helpers
- add `LoginPage` and `RequireAuth` gate for routes
- show a logout button in `ThemeToggle`
- protect existing routes in `App` and register the new login route
- wrap the app with `AuthProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '/workspace/REACT-APP/my-blog/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_684f0ee7f0108326a0106ae4c6c737de