### PR TITLE
Add vitest and sample tests

### DIFF
--- a/my-blog/package.json
+++ b/my-blog/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "backend": "json-server --watch db.json --port 3001"
+    "backend": "json-server --watch db.json --port 3001",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -31,6 +32,10 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^14.1.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/my-blog/src/__tests__/BlogForm.test.tsx
+++ b/my-blog/src/__tests__/BlogForm.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import BlogForm from '../components/BlogForm';
+
+describe('BlogForm', () => {
+  it('calls onSubmit with form values', async () => {
+    const handleSubmit = vi.fn();
+    render(<BlogForm onSubmit={handleSubmit} initialData={null} />);
+
+    await userEvent.type(screen.getByPlaceholderText('عنوان'), 'title');
+    await userEvent.type(screen.getByPlaceholderText('محتوا'), 'content');
+    await userEvent.type(screen.getByPlaceholderText('دسته‌بندی (اختیاری)'), 'cat');
+
+    await userEvent.click(screen.getByRole('button', { name: /افزودن پست/i }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      title: 'title',
+      content: 'content',
+      category: 'cat',
+      image: '',
+    });
+  });
+});

--- a/my-blog/src/setupTests.ts
+++ b/my-blog/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/my-blog/vite.config.ts
+++ b/my-blog/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/setupTests.ts'
+  }
 })


### PR DESCRIPTION
## Summary
- install vitest & testing-library packages
- configure vitest in `vite.config.ts`
- add `test` npm script
- add setup file for jest-dom
- write a basic BlogForm test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685000a403388326aac18c23026db4f8