### PR TITLE
Add VITE_API_URL env support

### DIFF
--- a/my-blog/.env
+++ b/my-blog/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/my-blog/README.md
+++ b/my-blog/README.md
@@ -53,3 +53,13 @@ export default tseslint.config({
 })
 ```
 \n## Dark Mode\n\nUse the theme toggle button in the top-right corner to switch between light and dark styles. Your choice is saved in localStorage.
+
+## تنظیم متغیرهای محیطی
+
+برای مشخص کردن آدرس سرور API فایلی به نام `.env` در ریشهٔ پروژه ایجاد کنید و متغیر زیر را در آن قرار دهید:
+
+```bash
+VITE_API_URL=http://localhost:3001
+```
+
+این مقدار در تمام درخواست‌های `fetch` استفاده شده و در صورت نیاز می‌توانید آن را تغییر دهید.

--- a/my-blog/src/context/BlogContext.tsx
+++ b/my-blog/src/context/BlogContext.tsx
@@ -13,7 +13,7 @@ export const BlogProvider = ({ children }: { children: React.ReactNode }) => {
   const [posts, setPosts] = useState<BlogPost[]>([]);
 
   const fetchPosts = () => {
-    fetch("http://localhost:3001/posts")
+    fetch(`${import.meta.env.VITE_API_URL}/posts`)
       .then(res => res.json())
       .then(data => setPosts(data));
   };

--- a/my-blog/src/pages/EditPost.tsx
+++ b/my-blog/src/pages/EditPost.tsx
@@ -9,13 +9,13 @@ export default function EditPost(){
     const [post, setPost] = useState(null);
 
     useEffect(() => {
-        fetch(`http://localhost:3001/posts/${id}`)
+        fetch(`${import.meta.env.VITE_API_URL}/posts/${id}`)
           .then(res => res.json())
           .then(data => setPost(data));
       }, [id]);
 
       const handleUpdate = (updatedPost: any) => {
-        fetch(`http://localhost:3001/posts/${id}`, {
+        fetch(`${import.meta.env.VITE_API_URL}/posts/${id}`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(updatedPost),

--- a/my-blog/src/pages/Home.tsx
+++ b/my-blog/src/pages/Home.tsx
@@ -19,7 +19,7 @@ function Home() {
         image: data.image || '',
       };
 
-      await fetch(`http://localhost:3001/posts/${editingPost.id}`, {
+      await fetch(`${import.meta.env.VITE_API_URL}/posts/${editingPost.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updated),
@@ -34,7 +34,7 @@ function Home() {
         image: data.image || '',
       };
       
-      const res = await fetch('http://localhost:3001/posts', {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/posts`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(newPost),
@@ -46,7 +46,7 @@ function Home() {
   };
 
   const deletePost = async (id: number) => {
-    const res = await fetch(`http://localhost:3001/posts/${id}`, {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/posts/${id}`, {
       method: 'DELETE',
     });
 

--- a/my-blog/src/pages/PostPage.tsx
+++ b/my-blog/src/pages/PostPage.tsx
@@ -8,7 +8,7 @@ function PostPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`http://localhost:3001/posts/${id}`)
+    fetch(`${import.meta.env.VITE_API_URL}/posts/${id}`)
       .then(res => {
         if (!res.ok) {
           throw new Error("پست پیدا نشد");


### PR DESCRIPTION
## Summary
- configure a `.env` file with `VITE_API_URL`
- use `import.meta.env.VITE_API_URL` for all fetch requests
- document how to set the API URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850009fe13c8326aa0e38beed949ccd