### PR TITLE
Switch tests to Jest

### DIFF
--- a/my-blog/jest.config.ts
+++ b/my-blog/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  globals: {
+    'ts-jest': {
+      useESM: true
+    }
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  setupFilesAfterEnv: ['./src/setupTests.ts']
+};
+
+export default config;

--- a/my-blog/package.json
+++ b/my-blog/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "backend": "json-server --watch db.json --port 3001",
-    "test": "vitest"
+    "test": "jest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -33,7 +33,10 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^1.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.8",
+    "jest-environment-jsdom": "^29.7.0",
     "@testing-library/react": "^14.1.0",
     "@testing-library/jest-dom": "^6.1.0",
     "@testing-library/user-event": "^14.4.3"

--- a/my-blog/src/__tests__/BlogForm.test.tsx
+++ b/my-blog/src/__tests__/BlogForm.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
 import BlogForm from '../components/BlogForm';
 
 describe('BlogForm', () => {
   it('calls onSubmit with form values', async () => {
-    const handleSubmit = vi.fn();
+    const handleSubmit = jest.fn();
     render(<BlogForm onSubmit={handleSubmit} initialData={null} />);
 
     await userEvent.type(screen.getByPlaceholderText('عنوان'), 'title');

--- a/my-blog/vite.config.ts
+++ b/my-blog/vite.config.ts
@@ -3,10 +3,5 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: './src/setupTests.ts'
-  }
+  plugins: [react()]
 })


### PR DESCRIPTION
## Summary
- replace vitest with jest in package.json
- remove vitest setup from vite config
- add jest config for ts-jest
- rewrite BlogForm test for jest

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500d10f3d48326b0ebfd2eb1865fca