### PR TITLE
Fix ts-jest configuration and add validation test

### DIFF
--- a/my-blog/jest.config.ts
+++ b/my-blog/jest.config.ts
@@ -1,18 +1,13 @@
 import type { Config } from 'jest';
 
 const config: Config = {
-  preset: 'ts-jest/presets/default-esm',
+  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   globals: {
     'ts-jest': {
-      useESM: true,
       tsconfig: './tsconfig.test.json'
 
     }
-  },
-  extensionsToTreatAsEsm: ['.ts', '.tsx'],
-  moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   setupFilesAfterEnv: ['./src/setupTests.ts']
 };

--- a/my-blog/src/__tests__/BlogForm.test.tsx
+++ b/my-blog/src/__tests__/BlogForm.test.tsx
@@ -20,4 +20,15 @@ describe('BlogForm', () => {
       image: '',
     });
   });
+
+  it('shows validation errors when required fields are missing', async () => {
+    const handleSubmit = jest.fn();
+    render(<BlogForm onSubmit={handleSubmit} initialData={null} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /افزودن پست/i }));
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText('عنوان الزامی است')).toBeInTheDocument();
+    expect(screen.getByText('محتوا الزامی است')).toBeInTheDocument();
+  });
 });

--- a/my-blog/tsconfig.test.json
+++ b/my-blog/tsconfig.test.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
-    "types": ["jest"]
+    "types": ["jest"],
+    "module": "CommonJS",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "verbatimModuleSyntax": false
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary
- adjust Jest config to use ts-jest with CJS
- override TypeScript test config for CommonJS modules
- test BlogForm validation messages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501724d0ec83268b1bde50a13c2951